### PR TITLE
Overpayment test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Run tests
         # Runs a script that creates a PostgreSQL client,
         # populates the client with data, and retrieves data
-        run: go test ./...
+        run: go test -cover ./...
         env:
           LNMUX_TEST_DB_DSN: "postgres://bottle_test:bottle_test@postgres/bottle_test?sslmode=disable"


### PR DESCRIPTION
This PR is a response to #10. In it:

- a new test is added which checks that overpaying HTLCs are rejected, including in combination, but an invoice is still accepted when the MPP set is complete
- a code coverage percentage is generated for each package and shown in the unit test logs