### PR TITLE
extract cancel and settle handling

### DIFF
--- a/cmd/lnmuxd/server.go
+++ b/cmd/lnmuxd/server.go
@@ -266,9 +266,6 @@ func (s *server) CancelInvoice(ctx context.Context,
 
 	err = s.registry.CancelInvoice(hash)
 	switch {
-	case err == types.ErrInvoiceNotFound:
-		return nil, status.Error(codes.NotFound, err.Error())
-
 	case err == lnmux.ErrInvoiceAlreadySettled:
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 

--- a/invoiceregistry_test.go
+++ b/invoiceregistry_test.go
@@ -112,7 +112,7 @@ func (r *registryTestContext) createInvoice(id int, expiry time.Duration) ( // n
 }
 
 func (r *registryTestContext) subscribe(hash lntypes.Hash) (chan InvoiceUpdate, func()) {
-	updateChan := make(chan InvoiceUpdate, 1)
+	updateChan := make(chan InvoiceUpdate, 2)
 	cancel, err := r.registry.Subscribe(hash, func(update InvoiceUpdate) {
 		updateChan <- update
 	})

--- a/lnmuxrpc/lnmux.proto
+++ b/lnmuxrpc/lnmux.proto
@@ -13,8 +13,13 @@ service Service {
 
     rpc SubscribeInvoiceAccepted (SubscribeInvoiceAcceptedRequest) returns (stream SubscribeInvoiceAcceptedResponse);
 
+    // Requests settlement for an accepted invoice. This call is idempotent.
     rpc SettleInvoice (SettleInvoiceRequest) returns (SettleInvoiceResponse);
 
+    // Cancels an accepted invoice. If the htlc set is no longer complete, the
+    // remaining htlcs are cancelled. If the htlc set is no longer existing, a
+    // success result is still returned. Only in case settle has been requested
+    // for an invoice, CancelInvoice returns a FailedPrecondition error.
     rpc CancelInvoice (CancelInvoiceRequest) returns (CancelInvoiceResponse);
 }
 

--- a/lnmuxrpc/lnmux_grpc.pb.go
+++ b/lnmuxrpc/lnmux_grpc.pb.go
@@ -22,7 +22,12 @@ type ServiceClient interface {
 	AddInvoice(ctx context.Context, in *AddInvoiceRequest, opts ...grpc.CallOption) (*AddInvoiceResponse, error)
 	SubscribeSingleInvoice(ctx context.Context, in *SubscribeSingleInvoiceRequest, opts ...grpc.CallOption) (Service_SubscribeSingleInvoiceClient, error)
 	SubscribeInvoiceAccepted(ctx context.Context, in *SubscribeInvoiceAcceptedRequest, opts ...grpc.CallOption) (Service_SubscribeInvoiceAcceptedClient, error)
+	// Requests settlement for an accepted invoice. This call is idempotent.
 	SettleInvoice(ctx context.Context, in *SettleInvoiceRequest, opts ...grpc.CallOption) (*SettleInvoiceResponse, error)
+	// Cancels an accepted invoice. If the htlc set is no longer complete, the
+	// remaining htlcs are cancelled. If the htlc set is no longer existing, a
+	// success result is still returned. Only in case settle has been requested
+	// for an invoice, CancelInvoice returns a FailedPrecondition error.
 	CancelInvoice(ctx context.Context, in *CancelInvoiceRequest, opts ...grpc.CallOption) (*CancelInvoiceResponse, error)
 }
 
@@ -142,7 +147,12 @@ type ServiceServer interface {
 	AddInvoice(context.Context, *AddInvoiceRequest) (*AddInvoiceResponse, error)
 	SubscribeSingleInvoice(*SubscribeSingleInvoiceRequest, Service_SubscribeSingleInvoiceServer) error
 	SubscribeInvoiceAccepted(*SubscribeInvoiceAcceptedRequest, Service_SubscribeInvoiceAcceptedServer) error
+	// Requests settlement for an accepted invoice. This call is idempotent.
 	SettleInvoice(context.Context, *SettleInvoiceRequest) (*SettleInvoiceResponse, error)
+	// Cancels an accepted invoice. If the htlc set is no longer complete, the
+	// remaining htlcs are cancelled. If the htlc set is no longer existing, a
+	// success result is still returned. Only in case settle has been requested
+	// for an invoice, CancelInvoice returns a FailedPrecondition error.
 	CancelInvoice(context.Context, *CancelInvoiceRequest) (*CancelInvoiceResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -143,7 +143,7 @@ func TestMux(t *testing.T) {
 		errChan <- mux.Run(ctx)
 	}()
 
-	var updateChan = make(chan InvoiceUpdate, 1)
+	var updateChan = make(chan InvoiceUpdate, 2)
 	cancelSubscription, err := registry.Subscribe(testHash, func(update InvoiceUpdate) {
 		logger.Sugar().Infow("Payment received", "state", update.State)
 


### PR DESCRIPTION
Also reduce error detail level so that callers don't need to worry
about incomplete htlc sets.