### PR TITLE
set_id: fix index increment from 8 to 16

### DIFF
--- a/set_id.go
+++ b/set_id.go
@@ -33,7 +33,7 @@ func newSetID(keys []types.CircuitKey) SetID {
 	for _, key := range sortedKeys {
 		byteOrder.PutUint64(keysBytes[idx:], key.ChanID)
 		byteOrder.PutUint64(keysBytes[idx+8:], key.HtlcID)
-		idx += 8
+		idx += 16
 	}
 
 	hash := sha256.Sum256(keysBytes)

--- a/set_id_test.go
+++ b/set_id_test.go
@@ -14,7 +14,7 @@ func TestSetID(t *testing.T) {
 		{ChanID: 2, HtlcID: 4},
 	}
 
-	expectedHash, _ := hex.DecodeString("cc70fcada0615d5f945db224c5d261d895f381f27298e9e1f96568c32825e3bd")
+	expectedHash, _ := hex.DecodeString("567123ef075dbb9e4d08093a9a52221f3e26ebe728310961d05232796083f1f7")
 
 	hash := newSetID(keys)
 	require.Equal(t, expectedHash, hash[:])


### PR DESCRIPTION
This changes the index increment from 8 to 16 in the set ID calculation loop for every member HTLC. It ensures a loop iteration doesn't overwrite a previous iteration's result but appends it. See comment at https://github.com/bottlepay/lnmux/pull/30#discussion_r929111197