### PR TITLE
Initial prometheus metrics support

### DIFF
--- a/cmd/lnmuxd/config.go
+++ b/cmd/lnmuxd/config.go
@@ -10,7 +10,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var DefaultListenAddress = "localhost:19090"
+var (
+	DefaultListenAddress          = "localhost:19090"
+	DefaultInstrumentationAddress = "localhost:2112"
+)
 
 type Config struct {
 	// Lnd contains the configuration of the nodes.
@@ -27,6 +30,10 @@ type Config struct {
 
 	// ListenAddress is the network address that we listen on.
 	ListenAddress string `yaml:"listenAddress"`
+
+	// InstrumentationAddress is the network address that Prometheus
+	// and eventually pprof and/or other instrumentation listen on.
+	InstrumentationAddress string `yaml:"instrumentationAddress"`
 }
 
 func (c *Config) GetIdentityKey() ([32]byte, error) {

--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,8 +18,10 @@ import (
 	"github.com/bottlepay/lnmux/persistence"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/go-pg/pg/v10"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -106,9 +109,13 @@ func runAction(c *cli.Context) error {
 		return err
 	}
 
-	// Instantiate grpc server.
-	grpcServer := grpc.NewServer()
+	// Instantiate grpc server and enable reflection and Prometheus metrics.
+	grpcServer := grpc.NewServer(
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	)
 	reflection.Register(grpcServer)
+	grpc_prometheus.Register(grpcServer)
 
 	server := newServer(creator, registry)
 
@@ -124,6 +131,24 @@ func runAction(c *cli.Context) error {
 	grpcInternalListener, err := net.Listen("tcp", listenAddress)
 	if err != nil {
 		return err
+	}
+
+	instAddress := cfg.InstrumentationAddress
+	if instAddress == "" {
+		instAddress = DefaultInstrumentationAddress
+	}
+
+	// Instantiate a new HTTP server and mux.
+	instMux := http.NewServeMux()
+	instMux.Handle("/metrics", promhttp.Handler())
+
+	instServer := &http.Server{
+		Addr:    instAddress,
+		Handler: instMux,
+
+		// Even though this server should only be exposed to trusted
+		// clients, this mitigates slowloris-like DoS attacks.
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	group, ctx := errgroup.WithContext(context.Background())
@@ -157,6 +182,22 @@ func runAction(c *cli.Context) error {
 		grpcServer.Stop()
 
 		return nil
+	})
+
+	group.Go(func() error {
+		log.Infow("Instrumentation HTTP server starting",
+			"instrumentationAddress", instAddress)
+
+		return instServer.ListenAndServe()
+	})
+
+	group.Go(func() error {
+		<-ctx.Done()
+
+		// Stop instrumentation server
+		log.Infow("Instrumentation server stopping")
+
+		return instServer.Close()
 	})
 
 	// Run ctrl-c handler.


### PR DESCRIPTION
This PR enables initial support of Prometheus monitoring, including basic GRPC client and server support, as specified by #15. Notably, adding custom metrics is out of scope for this PR and will be done as part of a PR addressing #23.