### PR TITLE
invoiceregistry_test: add test for accept timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_DB: bottle_test
           POSTGRES_USER: bottle_test
           POSTGRES_PASSWORD: bottle_test
 
@@ -28,4 +27,4 @@ jobs:
         # populates the client with data, and retrieves data
         run: go test -cover ./...
         env:
-          LNMUX_TEST_DB_DSN: "postgres://bottle_test:bottle_test@postgres/bottle_test?sslmode=disable"
+          LNMUX_TEST_DB_DSN: "postgres://bottle_test:bottle_test@postgres/postgres?sslmode=disable"

--- a/invoiceregistry.go
+++ b/invoiceregistry.go
@@ -496,7 +496,7 @@ func (i *InvoiceRegistry) failInvoice(hash lntypes.Hash) error {
 
 	// Cancel all accepted htlcs.
 	set.deleteAll(func(key types.CircuitKey) {
-		i.notifyHodlSubscribers(key, NewFailResolution(ResultInvoiceExpired))
+		i.notifyHodlSubscribers(key, NewFailResolution(ResultAcceptTimeout))
 	})
 
 	logger.Infow("Failed invoice")

--- a/invoiceregistry_test.go
+++ b/invoiceregistry_test.go
@@ -348,7 +348,7 @@ func TestAcceptTimeout(t *testing.T) {
 
 	accept := <-acceptChan
 
-	c.checkHtlcFailed(<-resolved, ResultInvoiceExpired)
+	c.checkHtlcFailed(<-resolved, ResultAcceptTimeout)
 
 	require.ErrorIs(t, c.registry.CancelInvoice(accept.hash, accept.setID), types.ErrInvoiceNotFound)
 }

--- a/invoiceregistry_test.go
+++ b/invoiceregistry_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bottlepay/lnmux/test"
 	"github.com/bottlepay/lnmux/types"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/go-pg/pg/v10"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -22,9 +21,9 @@ import (
 type registryTestContext struct {
 	t               *testing.T
 	registry        *InvoiceRegistry
-	pg              *pg.DB
 	cfg             *RegistryConfig
 	db              *persistence.PostgresPersister
+	dropDB          func()
 	cancelRegistry  func()
 	registryErrChan chan error
 	logger          *zap.SugaredLogger
@@ -37,7 +36,7 @@ type registryTestContext struct {
 func newRegistryTestContext(t *testing.T, autoSettle bool) *registryTestContext {
 	logger, _ := zap.NewDevelopment()
 
-	pg, db := setupTestDB(t)
+	db, dropDB := setupTestDB(t)
 
 	keyRing := NewKeyRing(testKey)
 
@@ -62,9 +61,9 @@ func newRegistryTestContext(t *testing.T, autoSettle bool) *registryTestContext 
 
 	c := &registryTestContext{
 		t:       t,
-		pg:      pg,
 		cfg:     cfg,
 		db:      db,
+		dropDB:  dropDB,
 		logger:  cfg.Logger,
 		testAmt: 10000,
 		creator: creator,
@@ -99,7 +98,7 @@ func (r *registryTestContext) stop() {
 func (r *registryTestContext) close() {
 	r.stop()
 
-	r.pg.Close()
+	r.dropDB()
 }
 
 func (r *registryTestContext) createInvoice(id int, expiry time.Duration) ( // nolint:unparam
@@ -141,6 +140,7 @@ func (r *registryTestContext) checkHtlcSettled(resolution HtlcResolution) {
 
 func TestInvoiceExpiry(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, false)
 
@@ -171,6 +171,7 @@ func TestInvoiceExpiry(t *testing.T) {
 
 func TestAutoSettle(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, true)
 
@@ -207,6 +208,7 @@ func TestAutoSettle(t *testing.T) {
 // application subscribed to accept events.
 func TestNoSubscriberFail(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, false)
 
@@ -233,6 +235,7 @@ func TestNoSubscriberFail(t *testing.T) {
 
 func TestSettle(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, false)
 
@@ -285,6 +288,7 @@ func TestSettle(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, false)
 
@@ -321,6 +325,7 @@ func TestCancel(t *testing.T) {
 
 func TestAcceptTimeout(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, false)
 
@@ -355,6 +360,7 @@ func TestAcceptTimeout(t *testing.T) {
 
 func TestOverpayment(t *testing.T) {
 	defer test.Timeout()()
+	t.Parallel()
 
 	c := newRegistryTestContext(t, true)
 

--- a/persistence/test/test.go
+++ b/persistence/test/test.go
@@ -3,6 +3,9 @@ package test
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bottlepay/lnmux/persistence/migrations"
@@ -12,9 +15,9 @@ import (
 
 const PGExpectedSchemaVersion = 1
 
+var dbSuffix uint32
+
 type TestDBSettings struct {
-	DSN                   string
-	Schema                string
 	MigrationsPath        string
 	ExpectedSchemaVersion int64
 }
@@ -22,38 +25,64 @@ type TestDBSettings struct {
 func PGTestDSN() string {
 	dsn, ok := os.LookupEnv("LNMUX_TEST_DB_DSN")
 	if !ok {
-		dsn = "postgres://bottle:bottle@localhost:45432/bottle_test?sslmode=disable"
+		dsn = "postgres://bottle:bottle@localhost:45432/postgres?sslmode=disable"
 	}
 
 	return dsn
 }
 
-func ResetPGTestDB(t *testing.T, settings *TestDBSettings) (*pg.DB, string) {
+func CreatePGTestDB(t *testing.T, settings *TestDBSettings) *pg.Options {
 
-	if settings.DSN == "" {
-		settings.DSN = PGTestDSN()
-	}
-	dsn := settings.DSN
-
-	if settings.Schema == "" {
-		settings.Schema = "lnmux"
-	}
+	// To create a DB, we need a connection to the server that isn't to
+	// the nonexistent DB itself. We connect to the postgres DB, which
+	// almost always exists.
+	dsn := PGTestDSN()
 
 	if settings.ExpectedSchemaVersion == 0 {
 		settings.ExpectedSchemaVersion = PGExpectedSchemaVersion
 	}
 
-	dbSettings, err := pg.ParseURL(settings.DSN)
+	dbSettings, err := pg.ParseURL(dsn)
 	require.NoError(t, err)
+
+	defaultDb := pg.Connect(dbSettings)
+	dbSettings = defaultDb.Options()
+
+	// Get the filename of the caller of this function. This lets us
+	// distinguish between different packages calling it, which prevents
+	// tests executing as multiple binaries from running over each other.
+	_, callerFileName, _, ok := runtime.Caller(1)
+	require.True(t, ok)
+
+	// Format the filename in a way we can insert it into the DB name.
+	// First, we split based on path separator.
+	callerPathParts := strings.Split(callerFileName,
+		string(os.PathSeparator))
+
+	// Then, we take the last two directories in the caller's filename.
+	// This way, it's not too long for a DB name, but still leaves some
+	// context about the package name.
+	numParts := len(callerPathParts)
+	callerFileName = strings.Join(callerPathParts[numParts-3:numParts-1],
+		"_")
+
+	// Combine caller package info with sequence to ensure unique DB per
+	// test inside the calling package.
+	dbName := fmt.Sprintf("bottle_test_%s_%d",
+		callerFileName, atomic.AddUint32(&dbSuffix, 1))
+
+	_, err = defaultDb.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s",
+		dbName))
 	require.NoError(t, err)
+
+	_, err = defaultDb.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+	require.NoError(t, err)
+
+	dbSettings.Database = dbName
+
+	defaultDb.Close()
 
 	db := pg.Connect(dbSettings)
-
-	_, err = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", settings.Schema))
-	require.NoError(t, err)
-
-	_, err = db.Exec(fmt.Sprintf("CREATE SCHEMA %s", settings.Schema))
-	require.NoError(t, err)
 
 	err = migrations.DiscoverSQLMigrations(settings.MigrationsPath)
 	require.NoError(t, err)
@@ -66,5 +95,24 @@ func ResetPGTestDB(t *testing.T, settings *TestDBSettings) (*pg.DB, string) {
 
 	require.Equal(t, settings.ExpectedSchemaVersion, newVersion)
 
-	return db, dsn
+	db.Close()
+
+	return dbSettings
+}
+
+func DropTestDB(t *testing.T, opts pg.Options) {
+	dbName := opts.Database
+
+	// To drop the DB, we need a connection to the server that isn't
+	// accessing the DB itself. We connect to the postgres DB, which
+	// almost always exists.
+	opts.Database = "postgres"
+
+	defaultDb := pg.Connect(&opts)
+
+	_, err := defaultDb.Exec(fmt.Sprintf("DROP DATABASE %s", dbName))
+	require.NoError(t, err)
+
+	defaultDb.Close()
+
 }

--- a/resolution_result.go
+++ b/resolution_result.go
@@ -46,11 +46,16 @@ const (
 	// the database.
 	ResultCannotSettle
 
+	// ResultInvoiceExpired is returned when an invoice has expired.
 	ResultInvoiceExpired
 
 	// ResultNoAcceptSubscriber is returned when an htlc is failed because there
 	// is no application subscribed to accept events.
 	ResultNoAcceptSubscriber
+
+	// ResultAcceptTimeout is returned when the accept timeout is reached
+	// without settlement after an invoice is accepted.
+	ResultAcceptTimeout
 )
 
 // String returns a string representation of the result.
@@ -101,6 +106,9 @@ func (f FailResolutionResult) FailureString() string {
 
 	case ResultNoAcceptSubscriber:
 		return "no accept subscriber"
+
+	case ResultAcceptTimeout:
+		return "accept timeout"
 
 	default:
 		return "unknown failure resolution result"


### PR DESCRIPTION
This adds a test for timing out an invoice after it's accepted but before a settle or cancel is requested. The following increase in test coverage is observed for the `mux` package:

```
ok      github.com/bottlepay/lnmux      2.715s  coverage: 75.7% of statements
```
vs
```
ok      github.com/bottlepay/lnmux      4.763s  coverage: 77.1% of statements
```

This closes #31 