### PR TITLE
interceptor: handle error channel on initial block height

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -102,6 +102,9 @@ func (i *interceptor) start(ctx context.Context) error {
 		i.logger.Debugw("Initial block height", "height", block.Height)
 		i.heightChan <- int(block.Height)
 
+	case err := <-blockErrChan:
+		return err
+
 	case <-time.After(initialBlockTimeout):
 		return errors.New("initial block height not received")
 


### PR DESCRIPTION
This PR handles the case where the interceptor gets an error when subscribing to block epoch notification. This can help surface problems such as `lnd` built without the `chainrpc` tag.