### PR TITLE
config.go: do not return error if there are unknown fields

### DIFF
--- a/cmd/lnmuxd/config.go
+++ b/cmd/lnmuxd/config.go
@@ -112,7 +112,7 @@ func loadConfig(filename string) (*Config, error) {
 	}
 
 	var cfg Config
-	err = yaml.UnmarshalStrict(yamlFile, &cfg)
+	err = yaml.Unmarshal(yamlFile, &cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Integrating lnmux in a production environment may require adding fields to the configuration ((We can imagine a system where the config needs to have specific fields to be accepted...).

However, it is currently not possible because we use UnmarshalStrict. We suggest using Unmarshal instead.