### PR TITLE
Add non-strict-config flag

### DIFF
--- a/cmd/lnmuxd/config.go
+++ b/cmd/lnmuxd/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
 )
 
@@ -108,14 +109,21 @@ type DbConfig struct {
 	IdleTimeout time.Duration `yaml:"idleTimeout"`
 }
 
-func loadConfig(filename string) (*Config, error) {
+func loadConfig(c *cli.Context) (*Config, error) {
+	filename := c.String("config")
+	nonStrictConfig := c.Bool(nonStrictConfigFlag.Name)
+
 	yamlFile, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	var cfg Config
-	err = yaml.Unmarshal(yamlFile, &cfg)
+	if nonStrictConfig {
+		err = yaml.Unmarshal(yamlFile, &cfg)
+	} else {
+		err = yaml.UnmarshalStrict(yamlFile, &cfg)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/lnmuxd/main.go
+++ b/cmd/lnmuxd/main.go
@@ -7,6 +7,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var nonStrictConfigFlag = &cli.BoolFlag{
+	Name:  "non-strict-config",
+	Usage: "If set to true, unknown config fields are silently ignored",
+}
+
 func main() {
 	app := &cli.App{
 		Name: "lnmuxd",
@@ -19,6 +24,7 @@ func main() {
 				Name:    "config",
 				Aliases: []string{"c"},
 			},
+			nonStrictConfigFlag,
 		},
 	}
 

--- a/cmd/lnmuxd/migrate.go
+++ b/cmd/lnmuxd/migrate.go
@@ -28,7 +28,7 @@ func migrateAction(c *cli.Context) error {
 		return cli.ShowCommandHelp(c, "migrate")
 	}
 
-	cfg, err := loadConfig(c.String("config"))
+	cfg, err := loadConfig(c)
 	if err != nil {
 		return err
 	}

--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -35,7 +35,7 @@ var runCommand = &cli.Command{
 }
 
 func runAction(c *cli.Context) error {
-	cfg, err := loadConfig(c.String("config"))
+	cfg, err := loadConfig(c)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lightningnetwork/lnd v0.14.1-beta.0.20220425101129-0845c4daeb1e
 	github.com/lightningnetwork/lnd/clock v1.1.0
 	github.com/lightningnetwork/lnd/queue v1.1.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.2.0
 	go.uber.org/zap v1.17.0
@@ -98,7 +99,6 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect


### PR DESCRIPTION
Bring back strict config parsing.

Non-strict parsing was introduced in https://github.com/bottlepay/lnmux/pull/48.