### PR TITLE
Enable race detection in CI, fix a data race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Run tests
         # Runs a script that creates a PostgreSQL client,
         # populates the client with data, and retrieves data
-        run: go test -cover ./...
+        run: go test -race -cover ./...
         env:
           LNMUX_TEST_DB_DSN: "postgres://bottle_test:bottle_test@postgres/postgres?sslmode=disable"


### PR DESCRIPTION
This PR enables race detection when running tests in CI. It also fixes a data race in the database migration discovery process, found automatically when running tests.

Fixes #64 