### PR TITLE
Add tests in `InvoiceRegistry` for MPP validity checks

### DIFF
--- a/invoiceregistry.go
+++ b/invoiceregistry.go
@@ -679,7 +679,7 @@ func (i *InvoiceRegistry) process(ctx context.Context, h *registryHtlc) error {
 	if statelessData.preimage.Hash() != h.rHash {
 		logger.Debugw("Hash mismatch")
 
-		h.resolve(NewFailResolution(ResultInvoiceNotFound))
+		h.resolve(NewFailResolution(ResultAddressMismatch))
 
 		return nil
 	}


### PR DESCRIPTION
This PR adds a test for some MPP validity checks in the `InvoiceRegistry`'s `process()` function. It currently increases code coverage for `invoiceregistry.go` from 78.9% to 83.3%, and coverage for the `process()` function specifically from 76.8% to 92.8%.

It also:
- fixes the return code when invoice and HTLC payment hash don't match
- adds a set of test utility functions for crafting and sending HTLCs to the registry
- adds a null MPP record type for tests

Fixes #62.