### PR TITLE
mux: remove unused persister field in Mux struct

### DIFF
--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -112,7 +112,6 @@ func runAction(c *cli.Context) error {
 			Lnd:             lnds,
 			Logger:          log,
 			Registry:        registry,
-			Persister:       db,
 			SettledHandler:  settledHandler,
 		})
 	if err != nil {

--- a/mux.go
+++ b/mux.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bottlepay/lnmux/common"
 	"github.com/bottlepay/lnmux/lnd"
-	"github.com/bottlepay/lnmux/persistence"
 	"github.com/bottlepay/lnmux/types"
 	"github.com/btcsuite/btcd/chaincfg"
 	sphinx "github.com/lightningnetwork/lightning-onion"
@@ -23,9 +22,8 @@ import (
 )
 
 type Mux struct {
-	registry  *InvoiceRegistry
-	sphinx    *hop.OnionProcessor
-	persister *persistence.PostgresPersister
+	registry *InvoiceRegistry
+	sphinx   *hop.OnionProcessor
 
 	lnd    []lnd.LndClient
 	logger *zap.SugaredLogger
@@ -36,7 +34,6 @@ type Mux struct {
 type MuxConfig struct {
 	KeyRing         keychain.SecretKeyRing
 	ActiveNetParams *chaincfg.Params
-	Persister       *persistence.PostgresPersister
 	SettledHandler  *SettledHandler
 
 	Lnd      []lnd.LndClient
@@ -70,7 +67,6 @@ func New(cfg *MuxConfig) (*Mux,
 	return &Mux{
 		registry:       cfg.Registry,
 		sphinx:         sphinx,
-		persister:      cfg.Persister,
 		lnd:            cfg.Lnd,
 		logger:         cfg.Logger,
 		settledHandler: cfg.SettledHandler,

--- a/mux_test.go
+++ b/mux_test.go
@@ -157,7 +157,6 @@ func TestMux(t *testing.T) {
 		Lnd:             []lnd.LndClient{l[0].client, l[1].client},
 		Logger:          logger.Sugar(),
 		Registry:        registry,
-		Persister:       db,
 		SettledHandler:  settledHandler,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
The `persister` field in the `Mux` struct is unused as only the invoice registry actually uses a persister. We may be able to remove it from the `Mux` struct if there are no plans for its future use.