### PR TITLE
Fix dlock behaviour and error handling 

### DIFF
--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -48,26 +48,14 @@ func runAction(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	group, ctx := errgroup.WithContext(ctx)
-
-	err = run(ctx, cfg, group)
-	if err != nil {
-		cancel()
-
-		// We don't need to catch the error since we only want to wait all goroutines to finish
-		_ = group.Wait()
-
-		return err
-	}
-
-	return group.Wait()
+	return initServiceWithLock(cfg.InstrumentationAddress, cfg.DistributedLock, func(ctx context.Context) error {
+		return run(ctx, cfg)
+	})
 }
 
-func run(ctx context.Context, cfg *Config, group *errgroup.Group) error {
-	// Run ctrl-c handler.
+func initServiceWithLock(address string, lockConfig DistributedLockConfig, run func(context.Context) error) error {
+	group, ctx := errgroup.WithContext(context.Background())
+
 	group.Go(func() error {
 		log.Infof("Press ctrl-c to exit")
 
@@ -83,8 +71,7 @@ func run(ctx context.Context, cfg *Config, group *errgroup.Group) error {
 		}
 	})
 
-	// Initialise instrumentation server
-	instServer := initInstrumentationServer(cfg.InstrumentationAddress)
+	instServer := initInstrumentationServer(address)
 
 	group.Go(func() error {
 		log.Infow("Instrumentation HTTP server starting",
@@ -102,13 +89,20 @@ func run(ctx context.Context, cfg *Config, group *errgroup.Group) error {
 		return instServer.Close()
 	})
 
-	// Get the K8s lock
-	releaseLock, err := initDistributedLock(ctx, &cfg.DistributedLock)
-	if err != nil {
-		return err
-	}
-	defer releaseLock()
+	group.Go(func() error {
+		releaseLock, err := initDistributedLock(ctx, &lockConfig)
+		if err != nil {
+			return err
+		}
+		defer releaseLock()
 
+		return run(ctx)
+	})
+
+	return group.Wait()
+}
+
+func run(ctx context.Context, cfg *Config) error {
 	// Setup persistence.
 	db, err := initPersistence(ctx, cfg)
 	if err != nil {
@@ -248,6 +242,8 @@ func run(ctx context.Context, cfg *Config, group *errgroup.Group) error {
 	if err != nil {
 		return err
 	}
+
+	group, ctx := errgroup.WithContext(ctx)
 
 	// Run multiplexer.
 	group.Go(func() error {

--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -280,7 +280,7 @@ func run(ctx context.Context, cfg *Config, group *errgroup.Group) error {
 		return nil
 	})
 
-	return nil
+	return group.Wait()
 }
 
 func initLndClients(ctx context.Context, cfg *LndConfig) ([]lnd.LndClient, *chaincfg.Params, error) {


### PR DESCRIPTION
2 fixes:

First, we need to do `errgroup.Wait()` in `run` function otherwise defer statements will be triggered. For example, if an instance acquires the lock, it will reach the end of `run` function and then trigger the `defer releaseLock()` (and another instance can acquire the lock)

Secondly, in this code:

```
func run(){

group.Go(func() error {
		log.Infow("Instrumentation HTTP server starting",
			"instrumentationAddress", instServer.Addr)
		return instServer.ListenAndServe()
	})
	
releaseLock, err := initDistributedLock(ctx, &cfg.DistributedLock)
	if err != nil {
		return err
	}
	
return group.Wait()

}
```

If we have an error when calling `instServer.ListenAndServe()`, we will return the error `context canceled` instead of the ListenAndServe error.
Indeed, the `ctx` in `initDistributedLock` is the `errgroup` context.
So , we will cancel the context if an error occurs in a Group.Go(), and then, initDistributedLock will return `context canceled`.