### PR TITLE
Add node to key

### DIFF
--- a/htlc_set.go
+++ b/htlc_set.go
@@ -6,15 +6,15 @@ import (
 )
 
 type htlcSet interface {
-	addHtlc(key types.CircuitKey, amt int64)
+	addHtlc(key types.HtlcKey, amt int64)
 
-	getHtlcMap() map[types.CircuitKey]int64
-	accepted(key types.CircuitKey) bool
+	getHtlcMap() map[types.HtlcKey]int64
+	accepted(key types.HtlcKey) bool
 	totalSetAmt() int64
 	isComplete() *SetID
 
-	deleteAll(cb func(types.CircuitKey))
-	deleteHtlc(key types.CircuitKey)
+	deleteAll(cb func(types.HtlcKey))
+	deleteHtlc(key types.HtlcKey)
 
 	hash() lntypes.Hash
 	paymentAddr() [32]byte
@@ -24,7 +24,7 @@ type htlcSet interface {
 
 type htlcSetImpl struct {
 	params htlcSetParameters
-	htlcs  map[types.CircuitKey]int64
+	htlcs  map[types.HtlcKey]int64
 
 	parent *htlcSetsImpl
 }
@@ -34,12 +34,12 @@ func newHtlcSetImpl(parent *htlcSetsImpl,
 
 	return &htlcSetImpl{
 		params: params,
-		htlcs:  make(map[types.CircuitKey]int64),
+		htlcs:  make(map[types.HtlcKey]int64),
 		parent: parent,
 	}
 }
 
-func (h *htlcSetImpl) deleteAll(cb func(types.CircuitKey)) {
+func (h *htlcSetImpl) deleteAll(cb func(types.HtlcKey)) {
 	for key := range h.htlcs {
 		cb(key)
 	}
@@ -61,7 +61,7 @@ func (h *htlcSetImpl) isComplete() *SetID {
 		return nil
 	}
 
-	var keys []types.CircuitKey
+	var keys []types.HtlcKey
 	for htlc := range h.htlcs {
 		keys = append(keys, htlc)
 	}
@@ -87,8 +87,8 @@ func (h *htlcSetImpl) preimage() lntypes.Preimage {
 	return h.params.preimage
 }
 
-func (h *htlcSetImpl) getHtlcMap() map[types.CircuitKey]int64 {
-	htlcMap := make(map[types.CircuitKey]int64)
+func (h *htlcSetImpl) getHtlcMap() map[types.HtlcKey]int64 {
+	htlcMap := make(map[types.HtlcKey]int64)
 	for key, amt := range h.htlcs {
 		htlcMap[key] = amt
 	}
@@ -96,13 +96,13 @@ func (h *htlcSetImpl) getHtlcMap() map[types.CircuitKey]int64 {
 	return htlcMap
 }
 
-func (h *htlcSetImpl) accepted(key types.CircuitKey) bool {
+func (h *htlcSetImpl) accepted(key types.HtlcKey) bool {
 	_, ok := h.htlcs[key]
 
 	return ok
 }
 
-func (h *htlcSetImpl) deleteHtlc(key types.CircuitKey) {
+func (h *htlcSetImpl) deleteHtlc(key types.HtlcKey) {
 	_, ok := h.htlcs[key]
 	if !ok {
 		panic("htlc not found")
@@ -115,7 +115,7 @@ func (h *htlcSetImpl) deleteHtlc(key types.CircuitKey) {
 	}
 }
 
-func (h *htlcSetImpl) addHtlc(key types.CircuitKey, amt int64) {
+func (h *htlcSetImpl) addHtlc(key types.HtlcKey, amt int64) {
 	if _, ok := h.htlcs[key]; ok {
 		panic("htlc already exists")
 	}

--- a/htlc_sets.go
+++ b/htlc_sets.go
@@ -8,7 +8,7 @@ import (
 type htlcSets interface {
 	get(hash lntypes.Hash) (htlcSet, bool)
 	forEach(cb func(htlcSet))
-	add(set *htlcSetParameters, htlcKey types.CircuitKey, htlcAmt int64) htlcSet
+	add(set *htlcSetParameters, htlcKey types.HtlcKey, htlcAmt int64) htlcSet
 }
 
 type htlcSetsImpl struct {
@@ -28,7 +28,7 @@ type htlcSetParameters struct {
 }
 
 // add adds a new htlc set and the first accepted htlc for that set.
-func (h *htlcSetsImpl) add(set *htlcSetParameters, htlcKey types.CircuitKey,
+func (h *htlcSetsImpl) add(set *htlcSetParameters, htlcKey types.HtlcKey,
 	htlcAmt int64) htlcSet {
 
 	hash := set.preimage.Hash()

--- a/interceptor.go
+++ b/interceptor.go
@@ -19,7 +19,7 @@ const (
 	resolutionQueueSize = 100
 )
 
-type preSendCallbackFunc func(context.Context, queuedReply) error
+type preSendCallbackFunc func(context.Context, common.PubKey, queuedReply) error
 
 type interceptor struct {
 	lnd             lnd.LndClient
@@ -147,7 +147,7 @@ func (i *interceptor) start(ctx context.Context) error {
 				return errors.New("reply channel full")
 			}
 
-			if err := i.preSendCallback(ctx, item); err != nil {
+			if err := i.preSendCallback(ctx, i.pubKey, item); err != nil {
 				return fmt.Errorf("pre-send callback failed: %w", err)
 			}
 

--- a/mux.go
+++ b/mux.go
@@ -369,13 +369,19 @@ func (p *Mux) ProcessHtlc(
 	}
 
 	// Notify the invoice registry of the intercepted htlc.
+	htlcKey := types.HtlcKey{
+		ChanID: htlc.circuitKey.ChanID,
+		HtlcID: htlc.circuitKey.HtlcID,
+		Node:   htlc.source,
+	}
+
 	p.registry.NotifyExitHopHtlc(
 		&registryHtlc{
 			rHash:         htlc.hash,
 			amtPaid:       lnwire.MilliSatoshi(htlc.outgoingAmountMsat),
 			expiry:        htlc.outgoingExpiry,
 			currentHeight: int32(height),
-			circuitKey:    htlc.circuitKey,
+			circuitKey:    htlcKey,
 			payload:       payload,
 			resolve: func(res HtlcResolution) {
 				err := resolve(res)

--- a/persistence/migrations/1_initial.up.sql
+++ b/persistence/migrations/1_initial.up.sql
@@ -15,6 +15,7 @@ CREATE TABLE invoices
 CREATE TABLE htlcs
 (
         "settle_requested_at"   TIMESTAMPTZ,
+        "node"                  BYTEA           NOT NULL CHECK (LENGTH(node) = 33),
         "hash"                  BYTEA           NOT NULL CHECK (LENGTH(hash) = 32),
         "chan_id"               BIGINT          NOT NULL,
         "htlc_id"               BIGINT          NOT NULL,
@@ -22,7 +23,7 @@ CREATE TABLE htlcs
         "settled"               BOOLEAN         NOT NULL DEFAULT FALSE,
         "settled_at"            TIMESTAMPTZ,
         
-        PRIMARY KEY (chan_id, htlc_id),
+        PRIMARY KEY (node, chan_id, htlc_id),
 
         CONSTRAINT fk_hash FOREIGN KEY(hash) REFERENCES invoices(hash) ON DELETE CASCADE
 );

--- a/persistence/pg.go
+++ b/persistence/pg.go
@@ -33,8 +33,8 @@ type InvoiceCreationData struct {
 type dbInvoice struct {
 	tableName struct{} `pg:"lnmux.invoices,discard_unknown_columns"` // nolint
 
-	Hash       lntypes.Hash     `pg:"hash,pk"`
-	Preimage   lntypes.Preimage `pg:"preimage"`
+	Hash       lntypes.Hash     `pg:"hash,use_zero,pk"`
+	Preimage   lntypes.Preimage `pg:"preimage,use_zero"`
 	AmountMsat int64            `pg:"amount_msat,use_zero"`
 
 	SettleRequestedAt time.Time `pg:"settle_requested_at"`
@@ -46,7 +46,7 @@ type dbInvoice struct {
 type dbHtlc struct {
 	tableName struct{} `pg:"lnmux.htlcs,discard_unknown_columns"` // nolint
 
-	Hash       lntypes.Hash `pg:"hash"`
+	Hash       lntypes.Hash `pg:"hash,use_zero"`
 	ChanID     uint64       `pg:"chan_id,use_zero,pk"`
 	HtlcID     uint64       `pg:"htlc_id,use_zero,pk"`
 	AmountMsat int64        `pg:"amount_msat,use_zero"`

--- a/persistence/pg_test.go
+++ b/persistence/pg_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bottlepay/lnmux/common"
 	"github.com/bottlepay/lnmux/persistence/test"
 	"github.com/bottlepay/lnmux/types"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -40,12 +41,15 @@ func TestSettleInvoice(t *testing.T) {
 	_, _, err := persister.Get(context.Background(), hash)
 	require.ErrorIs(t, err, types.ErrInvoiceNotFound)
 
-	htlcs := map[types.CircuitKey]int64{
+	nodeKey := common.PubKey{1}
+	htlcs := map[types.HtlcKey]int64{
 		{
+			Node:   nodeKey,
 			ChanID: 10,
 			HtlcID: 11,
 		}: 70,
 		{
+			Node:   nodeKey,
 			ChanID: 11,
 			HtlcID: 12,
 		}: 30,
@@ -58,20 +62,23 @@ func TestSettleInvoice(t *testing.T) {
 		},
 	}, htlcs))
 
-	_, err = persister.MarkHtlcSettled(context.Background(), hash, types.CircuitKey{
+	_, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+		Node:   nodeKey,
 		ChanID: 99,
 		HtlcID: 99,
 	})
 	require.ErrorIs(t, err, types.ErrHtlcNotFound)
 
-	invoiceSettled, err := persister.MarkHtlcSettled(context.Background(), hash, types.CircuitKey{
+	invoiceSettled, err := persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+		Node:   nodeKey,
 		ChanID: 10,
 		HtlcID: 11,
 	})
 	require.NoError(t, err)
 	require.False(t, invoiceSettled)
 
-	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.CircuitKey{
+	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+		Node:   nodeKey,
 		ChanID: 10,
 		HtlcID: 11,
 	})
@@ -82,7 +89,8 @@ func TestSettleInvoice(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, invoice.Settled)
 
-	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.CircuitKey{
+	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+		Node:   nodeKey,
 		ChanID: 11,
 		HtlcID: 12,
 	})

--- a/release_event.go
+++ b/release_event.go
@@ -28,7 +28,7 @@ type htlcReleaseEvent struct {
 	eventBase
 
 	// key is the circuit key of the htlc to release.
-	key types.CircuitKey
+	key types.HtlcKey
 }
 
 // Less is used to order PriorityQueueItem's by their release time such that

--- a/set_id_test.go
+++ b/set_id_test.go
@@ -4,26 +4,59 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/bottlepay/lnmux/common"
 	"github.com/bottlepay/lnmux/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetID(t *testing.T) {
-	keys := []types.CircuitKey{
-		{ChanID: 1, HtlcID: 3},
-		{ChanID: 2, HtlcID: 4},
+	testKeys := func() []types.HtlcKey {
+		return []types.HtlcKey{
+			{ChanID: 1, HtlcID: 3},
+			{ChanID: 2, HtlcID: 4},
+		}
 	}
 
-	expectedHash, _ := hex.DecodeString("567123ef075dbb9e4d08093a9a52221f3e26ebe728310961d05232796083f1f7")
-
+	keys := testKeys()
+	expectedHash, _ := hex.DecodeString("ae4aae558656bd09cba89b3857513eff4de4b0f10daaffd40f1807edc965b17f")
 	hash := newSetID(keys)
 	require.Equal(t, expectedHash, hash[:])
 
+	keys = testKeys()
 	keys[0], keys[1] = keys[1], keys[0]
 	hash = newSetID(keys)
 	require.Equal(t, expectedHash, hash[:])
 
+	keys = testKeys()
+	keys[0].Node = common.PubKey{1}
+	hash = newSetID(keys)
+	require.NotEqual(t, expectedHash, hash[:])
+
+	keys = testKeys()
+	keys[0].ChanID = 2
+	hash = newSetID(keys)
+	require.NotEqual(t, expectedHash, hash[:])
+
+	keys = testKeys()
 	keys[0].HtlcID = 5
 	hash = newSetID(keys)
 	require.NotEqual(t, expectedHash, hash[:])
+}
+
+// TestSetIDSelfPayments tests that two payments in different directions between
+// our own nodes result in a different set id. Htlc ids are counted per
+// direction separately and do not unique identify an htlc on the channel in any
+// direction.
+func TestSetIDSelfPayments(t *testing.T) {
+	payment1 := []types.HtlcKey{
+		{Node: common.PubKey{1}, ChanID: 1, HtlcID: 3},
+	}
+	hash1 := newSetID(payment1)
+
+	payment2 := []types.HtlcKey{
+		{Node: common.PubKey{2}, ChanID: 1, HtlcID: 3},
+	}
+	hash2 := newSetID(payment2)
+
+	require.NotEqual(t, hash1, hash2)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/bottlepay/lnmux/common"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -51,4 +52,15 @@ type CircuitKey struct {
 // String returns a string representation of the CircuitKey.
 func (k CircuitKey) String() string {
 	return fmt.Sprintf("%d:%d", k.ChanID, k.HtlcID)
+}
+
+type HtlcKey struct {
+	Node   common.PubKey
+	ChanID uint64
+	HtlcID uint64
+}
+
+// String returns a string representation of the HtlcKey.
+func (k HtlcKey) String() string {
+	return fmt.Sprintf("%v:%d:%d", k.Node, k.ChanID, k.HtlcID)
 }


### PR DESCRIPTION
Fixes bug where two nodes connected to multiplexer share a channel and cause circuit key collisions.

Circuit format in logs: `circuit=02a508a76083ef51bd60c994f5756e16aaafa946a29886397f411f3da0b32aa6ea:4039605720580096:19`