### PR TITLE
idempotent htlc settle

### DIFF
--- a/persistence/pg.go
+++ b/persistence/pg.go
@@ -199,21 +199,23 @@ func (p *PostgresPersister) MarkHtlcSettled(ctx context.Context,
 			return err
 		}
 
-		if count == 0 {
-			_, err := tx.ModelContext(ctx, (*dbInvoice)(nil)).
-				Where("hash=?", hash).
-				Set("settled=?", true).
-				Set("settled_at=?", now).
-				Update() // nolint:contextcheck
-			if err != nil {
-				return err
-			}
-			if result.RowsAffected() == 0 {
-				return types.ErrInvoiceNotFound
-			}
-
-			invoiceSettled = true
+		if count != 0 {
+			return nil
 		}
+
+		_, err = tx.ModelContext(ctx, (*dbInvoice)(nil)).
+			Where("hash=?", hash).
+			Set("settled=?", true).
+			Set("settled_at=?", now).
+			Update() // nolint:contextcheck
+		if err != nil {
+			return err
+		}
+		if result.RowsAffected() == 0 {
+			return types.ErrInvoiceNotFound
+		}
+
+		invoiceSettled = true
 
 		return nil
 	})

--- a/persistence/pg_test.go
+++ b/persistence/pg_test.go
@@ -62,14 +62,14 @@ func TestSettleInvoice(t *testing.T) {
 		},
 	}, htlcs))
 
-	_, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+	_, err = persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
 		Node:   nodeKey,
 		ChanID: 99,
 		HtlcID: 99,
 	})
 	require.ErrorIs(t, err, types.ErrHtlcNotFound)
 
-	invoiceSettled, err := persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+	invoiceSettled, err := persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
 		Node:   nodeKey,
 		ChanID: 10,
 		HtlcID: 11,
@@ -77,7 +77,7 @@ func TestSettleInvoice(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, invoiceSettled)
 
-	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
 		Node:   nodeKey,
 		ChanID: 10,
 		HtlcID: 11,
@@ -89,7 +89,7 @@ func TestSettleInvoice(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, invoice.Settled)
 
-	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), hash, types.HtlcKey{
+	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
 		Node:   nodeKey,
 		ChanID: 11,
 		HtlcID: 12,

--- a/persistence/pg_test.go
+++ b/persistence/pg_test.go
@@ -77,13 +77,12 @@ func TestSettleInvoice(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, invoiceSettled)
 
-	invoiceSettled, err = persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
+	_, err = persister.MarkHtlcSettled(context.Background(), types.HtlcKey{
 		Node:   nodeKey,
 		ChanID: 10,
 		HtlcID: 11,
 	})
-	require.NoError(t, err)
-	require.False(t, invoiceSettled)
+	require.Error(t, err, ErrHtlcAlreadySettled)
 
 	invoice, _, err := persister.Get(context.Background(), hash)
 	require.NoError(t, err)

--- a/settled_handler.go
+++ b/settled_handler.go
@@ -47,7 +47,13 @@ func (p *SettledHandler) preSendHandler(ctx context.Context, node common.PubKey,
 	}
 
 	invoiceSettled, err := p.persister.MarkHtlcSettled(ctx, htlcKey)
-	if err != nil {
+	switch {
+	// If htlc is already marked as settled, exit early. This can happen when
+	// the settle instruction didn't reach lnd in a previous run.
+	case err == persistence.ErrHtlcAlreadySettled:
+		return nil
+
+	case err != nil:
 		return err
 	}
 

--- a/settled_handler.go
+++ b/settled_handler.go
@@ -46,9 +46,7 @@ func (p *SettledHandler) preSendHandler(ctx context.Context, node common.PubKey,
 		HtlcID: item.incomingKey.HtlcID,
 	}
 
-	invoiceSettled, err := p.persister.MarkHtlcSettled(
-		ctx, item.hash, htlcKey,
-	)
+	invoiceSettled, err := p.persister.MarkHtlcSettled(ctx, htlcKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a bug where the interceptor would keep breaking on the error that was returned when the htlc was already settled in the database.