### PR TITLE
use global lnd client timeouts

### DIFF
--- a/cmd/lnmuxd/config.go
+++ b/cmd/lnmuxd/config.go
@@ -135,9 +135,6 @@ type LndConfig struct {
 
 	// Network is the bitcoin network that the connector is running on. Options: mainnet, testnet, regtest.
 	Network string `yaml:"network"`
-
-	// Timeout is a generic time limit waiting for calls to lnd to complete
-	Timeout time.Duration `yaml:"timeout"`
 }
 
 type DbConfig struct {

--- a/cmd/lnmuxd/run.go
+++ b/cmd/lnmuxd/run.go
@@ -324,7 +324,6 @@ func initLndClients(ctx context.Context, cfg *LndConfig) ([]lnd.LndClient, *chai
 			Logger:       log,
 			PubKey:       pubkey,
 			Network:      network,
-			Timeout:      cfg.Timeout,
 		})
 		if err != nil {
 			return nil, nil, err

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/bottlepay/lnmux/common"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -49,7 +48,6 @@ type Config struct {
 	LndUrl       string
 	Network      *chaincfg.Params
 	PubKey       common.PubKey
-	Timeout      time.Duration
 
 	Logger *zap.SugaredLogger
 }
@@ -74,8 +72,6 @@ func NewLndClient(ctx context.Context, cfg Config) (LndClient, error) {
 	}
 
 	// Test the lnd connection if it is available.
-	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
-	defer cancel()
 	getInfoResp, err := client.lnClient.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		logger.Warnw("Node unavailable, skipping parameter check",
@@ -153,10 +149,7 @@ func (l *lndClient) HtlcInterceptor(ctx context.Context) (
 	func() (*routerrpc.ForwardHtlcInterceptRequest, error),
 	error) {
 
-	infoCtx, cancel := context.WithTimeout(ctx, l.cfg.Timeout)
-	defer cancel()
-
-	infoResp, err := l.lnClient.GetInfo(infoCtx, &lnrpc.GetInfoRequest{})
+	infoResp, err := l.lnClient.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Clients should always guard their own timeouts. Additionally a standard timeouts helps to pull stream timeouts into the happy flow and surfaces potential issues sooner.