### PR TITLE
remove source field from interceptor output

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -226,7 +226,6 @@ func (i *interceptor) htlcReceiveLoop(ctx context.Context,
 
 		select {
 		case i.htlcChan <- &interceptedHtlc{
-			source:             i.pubKey,
 			circuitKey:         circuitKey,
 			hash:               hash,
 			onionBlob:          htlc.OnionBlob,


### PR DESCRIPTION
Next step in isolating per-node logic.