### PR TITLE
build: golang 1.19

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    container: golang:1.18
+    container: golang:1.19
 
     services:
       postgres:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build
+FROM golang:1.19-alpine AS build
 
 COPY . /go/src/github.com/bottlepay/lnmux
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bottlepay/lnmux
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bottlepay/lnmux/lnmuxrpc v0.0.0-00010101000000-000000000000

--- a/lnmuxrpc/go.mod
+++ b/lnmuxrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/bottlepay/lnmux/lnmuxrpc
 
-go 1.18
+go 1.19
 
 require (
 	google.golang.org/grpc v1.53.0


### PR DESCRIPTION
Concrete reason to bump was the use of `atomic.Bool` in the final settle pr #106. But it is a good idea to upgrade to current stable anyway. 