### PR TITLE
fix 'gosec' linter error in tests

### DIFF
--- a/persistence/test/test.go
+++ b/persistence/test/test.go
@@ -25,6 +25,7 @@ type TestDBSettings struct {
 func PGTestDSN() string {
 	dsn, ok := os.LookupEnv("LNMUX_TEST_DB_DSN")
 	if !ok {
+		//nolint:gosec
 		dsn = "postgres://bottle:bottle@localhost:45432/postgres?sslmode=disable"
 	}
 


### PR DESCRIPTION
gosec linter detects a "hardcoded password in a URL". We have indeed added a fallback url for PG instances in the test to be more practical.

We add `//nolint: gosec` for the given line to fix github's actions. (otherwise we can force the user to set the `LNMUX_TEST_DB_DSN` environment variable)